### PR TITLE
Fix git repository URL

### DIFF
--- a/lib/gitolite/patches/repositories_controller_patch.rb
+++ b/lib/gitolite/patches/repositories_controller_patch.rb
@@ -14,7 +14,7 @@ module GitoliteRedmine
       def edit_with_scm_settings
         params[:repository] ||= {}
         params[:repository][:extra_report_last_commit] = '1'
-        params[:repository][:url] = File.join(Setting.plugin_redmine_gitolite['basePath'],@project.identifier,".git") if  params[:repository_scm] == 'Git'
+        params[:repository][:url] = File.join(Setting.plugin_redmine_gitolite['basePath'],@project.identifier + ".git") if  params[:repository_scm] == 'Git'
         edit_without_scm_settings
       end
 


### PR DESCRIPTION
In the repository controller patch, the redefine of the repository url, the File.join was wrong : it generate an url like "/home/git/test/.git" instead of "/home/git/test.git".
