### PR TITLE
bug/typo in app/models/gitolite_observer.rb

### DIFF
--- a/app/models/gitolite_observer.rb
+++ b/app/models/gitolite_observer.rb
@@ -10,7 +10,7 @@ class GitoliteObserver < ActiveRecord::Observer
     gr = GitoliteRedmine::AdminHandler.new
     case object
       when Repository then gr.update_projects(object.project)
-      when User then (gr.update_gitolite(object.projects) && gr.update_user(object)) unless is_login_save?(object)
+      when User then (gr.update_projects(object.projects) && gr.update_user(object)) unless is_login_save?(object)
       when GitolitePublicKey then gr.update_user(object.user)
       when Member then gr.update_projects(object.project)
       when Role then gr.update_projects(object.members.map(&:project).uniq.compact)


### PR DESCRIPTION
Looks like app/models/gitolite_observer.rb line 13, should point to gr.update_projects, not gr.update_gitolite
