### PR TITLE
Fix for repository updates from remote gitolite server

### DIFF
--- a/app/controllers/gitolite_hook_controller.rb
+++ b/app/controllers/gitolite_hook_controller.rb
@@ -28,7 +28,7 @@ class GitoliteHookController < ApplicationController
   def update_repository(repository)
     origin = Setting.plugin_redmine_gitolite['developerBaseUrls'].lines.first
     origin = origin.gsub("%{name}", repository.project.identifier)
-    exec("git clone --bare '#{origin}' '#{repository.url}'") if !File.directory?(repository.url)
+    exec("git clone --mirror '#{origin}' '#{repository.url}'") if !File.directory?(repository.url)
     exec("cd '#{repository.url}' && git fetch origin && git reset --soft FETCH_HEAD")
   end
 


### PR DESCRIPTION
I needed this fix to allow redmine to properly update after the local cached copy of a repo from a remote gitolite server.  Without it, the git does not know here the remote repo is, and can not fetch updates.
