### PR TITLE
Fix branches showing up incorrectly in the Repository Browser

### DIFF
--- a/app/controllers/gitolite_hook_controller.rb
+++ b/app/controllers/gitolite_hook_controller.rb
@@ -29,7 +29,7 @@ class GitoliteHookController < ApplicationController
     origin = Setting.plugin_redmine_gitolite['developerBaseUrls'].lines.first
     origin = origin.gsub("%{name}", repository.project.identifier)
     exec("git clone --mirror '#{origin}' '#{repository.url}'") if !File.directory?(repository.url)
-    exec("cd '#{repository.url}' && git remote update")
+    exec("cd '#{repository.url}' && git remote update --prune")
   end
 
   def get_identifier

--- a/app/controllers/gitolite_hook_controller.rb
+++ b/app/controllers/gitolite_hook_controller.rb
@@ -29,7 +29,7 @@ class GitoliteHookController < ApplicationController
     origin = Setting.plugin_redmine_gitolite['developerBaseUrls'].lines.first
     origin = origin.gsub("%{name}", repository.project.identifier)
     exec("git clone --mirror '#{origin}' '#{repository.url}'") if !File.directory?(repository.url)
-    exec("cd '#{repository.url}' && git fetch origin && git reset --soft FETCH_HEAD")
+    exec("cd '#{repository.url}' && git remote update")
   end
 
   def get_identifier


### PR DESCRIPTION
Fixed git command to update the mirror (bare) repos correctly, prior to this commit, branches were getting overwritten and therefore not appearing correctly in the Repository Browser in Redmine.
