### PR TITLE
Added SSH Key Validation

### DIFF
--- a/app/models/gitolite_public_key.rb
+++ b/app/models/gitolite_public_key.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 class GitolitePublicKey < ActiveRecord::Base
   STATUS_ACTIVE = 1
   STATUS_LOCKED = 0
@@ -10,7 +12,7 @@ class GitolitePublicKey < ActiveRecord::Base
   named_scope :active, {:conditions => {:active => GitolitePublicKey::STATUS_ACTIVE}}
   named_scope :inactive, {:conditions => {:active => GitolitePublicKey::STATUS_LOCKED}}
   
-  validate :has_not_been_changed
+  validate :has_not_been_changed, :is_valid_key
   
   before_validation :set_identifier
   
@@ -19,6 +21,37 @@ class GitolitePublicKey < ActiveRecord::Base
       %w(identifier key user_id).each do |attribute|
         errors.add(attribute, 'may not be changed') unless changes[attribute].blank?
       end
+    end
+  end
+
+  def is_valid_key
+    valid = check_key(key)
+    if !valid
+      begin
+        key = "#{key}\n"
+        valid = check_key(key)
+        if !valid
+          errors[:base] = "invalid key"
+        else
+          self.key = key
+        end
+      rescue
+        errors[:key] = "invalid key"
+      end
+    end
+  end
+
+  def check_key(key)
+    File.open('/tmp/check_key', 'w') {|f| f.write(key)}
+    stdin, stdout, stderr = Open3.popen3('ssh-keygen -l -f /tmp/check_key')
+    data = stdout.gets()
+    hash_regex = /([0-9a-f][0-9a-f](:[0-9a-f][0-9a-f])+)/
+    matching = hash_regex.match data
+    File.delete('/tmp/check_key')
+    if matching == nil
+      false
+    else
+      true
     end
   end
   

--- a/app/models/gitolite_public_key.rb
+++ b/app/models/gitolite_public_key.rb
@@ -28,6 +28,8 @@ class GitolitePublicKey < ActiveRecord::Base
     valid = check_key(key)
     if !valid
       begin
+        # We try validating again, after adding a newline, since some 4096-bit
+        # public keys fail validation when a newline isn't present
         key = "#{key}\n"
         valid = check_key(key)
         if !valid
@@ -36,7 +38,7 @@ class GitolitePublicKey < ActiveRecord::Base
           self.key = key
         end
       rescue
-        errors[:key] = "invalid key"
+        errors[:base] = "invalid key"
       end
     end
   end


### PR DESCRIPTION
Added SSH Key validation, similar to how Gitolite validates keys. This way a user has to enter a valid SSH Key before it even goes to Gitolite. Also added support for 4096-bit keys, since most fail validation using ssh-keygen, if there is no newline present.
