### PR TITLE
Fixed repos not appearing in sidebar

### DIFF
--- a/app/views/repositories/git_instructions.html.erb
+++ b/app/views/repositories/git_instructions.html.erb
@@ -1,7 +1,7 @@
 <%# This is used to display basic git setup instructions, like on github... %>
 <% flash.now[:error] = "Repository does not exist. Create one using the instructions below." %>
 <div class="box">
-	
+
 <h2>Git Setup:</h2>
 <pre>  <a href="http://git-scm.com/download" target="_blank">Download and Install Git</a>
   git config --global user.name "<%= User.current.login %>"
@@ -26,6 +26,20 @@
 <pre>  cd existing_git_repo
   git remote add origin <%= Setting.plugin_redmine_gitolite['developerBaseUrls'].gsub("%{name}", @project.identifier) %>
   git push origin master
-</pre>    
-  
+</pre>
+
 </div>
+
+<% if @repositories.size > 1 %>
+  <% content_for :sidebar do %>
+    <h3><%= l(:label_repository_plural) %></h3>
+    <p>
+      <%= @repositories.sort.collect {|repo|
+          link_to h(repo.name),
+                  {:controller => 'repositories', :action => 'show',
+                   :id => @project, :repository_id => repo.identifier_param, :rev => nil, :path => nil},
+                  :class => 'repository' + (repo == @repository ? ' selected' : '')
+        }.join('<br />').html_safe %>
+    </p>
+  <% end %>
+<% end %>

--- a/lib/gitolite/patches/repositories_controller_patch.rb
+++ b/lib/gitolite/patches/repositories_controller_patch.rb
@@ -5,24 +5,25 @@ module GitoliteRedmine
 
       def show_with_git_instructions
         if @repository.is_a?(Repository::Git) and @repository.entries(@path, @rev).blank?
-          render :action => 'git_instructions' 
+          @repositories = @project.repositories
+          render :action => 'git_instructions'
         else
           show_without_git_instructions
         end
       end
-      
+
       def edit_with_scm_settings
-        git_parametrize 
+        git_parametrize
         edit_without_scm_settings
       end
 
       def update_with_scm_settings
-        git_parametrize 
+        git_parametrize
         update_without_scm_settings
       end
 
       def create_with_scm_settings
-        git_parametrize 
+        git_parametrize
         create_without_scm_settings
       end
 
@@ -37,7 +38,7 @@ module GitoliteRedmine
       end
 
       private
-      
+
       def git_parametrize
         params[:repository] ||= {}
         params[:repository][:extra_report_last_commit] = '1'


### PR DESCRIPTION
When a project has multiple repos and you view an empty repo, you get the "git instructions" view but with no sidebar. This pull request fixes that.
